### PR TITLE
bugfix: uninitialized constant ActiveSupport::Logger

### DIFF
--- a/paraduct.gemspec
+++ b/paraduct.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "activesupport"
+  spec.add_dependency "activesupport", ">= 4.0.0"
   spec.add_dependency "colorize"
   spec.add_dependency "rsync"
   spec.add_dependency "thor"


### PR DESCRIPTION
because: `ActiveSupport::Logger` is not exists in activesupport < 4
