### PR TITLE
Stop support ruby 1.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: ruby
 rvm:
-- 1.9
 - 2.0
 - 2.1
 - 2.2

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Paraduct (**parallel** + **parameterize** + **product**) is matrix test runner
 ![architecture](img/architecture.png)
 
 ## Requirements
-* ruby 1.9+
+* ruby 2.0+
 * rsync
 
 ## Installation

--- a/lib/paraduct/runner.rb
+++ b/lib/paraduct/runner.rb
@@ -5,7 +5,7 @@ module Paraduct
     attr_reader :script, :params, :base_job_dir
 
     # @params script [String, Array<String>] script file, script(s)
-    # @params params [Hash{String => String}] key is capitalized and value is quoted (ex. foo=1 => FOO="1" )
+    # @params params [Hash{String => String}] value is quoted (ex. FOO=1 => FOO="1" )
     # @params base_job_dir [String]
     # @params job_id [String]
     def initialize(script: nil, params: nil, base_job_dir: nil, job_id: nil)

--- a/lib/paraduct/runner.rb
+++ b/lib/paraduct/runner.rb
@@ -4,15 +4,15 @@ module Paraduct
   class Runner
     attr_reader :script, :params, :base_job_dir
 
-    # @param args
-    # @option args :script [String, Array<String>] script file, script(s)
-    # @option args :params [Hash{String => String}] key is capitalized and value is quoted (ex. foo=1 => FOO="1" )
-    # @option args :base_job_dir [String]
-    def initialize(args={})
-      @script       = args[:script]
-      @params       = args[:params]
-      @base_job_dir = args[:base_job_dir]
-      @job_id       = args[:job_id]
+    # @params script [String, Array<String>] script file, script(s)
+    # @params params [Hash{String => String}] key is capitalized and value is quoted (ex. foo=1 => FOO="1" )
+    # @params base_job_dir [String]
+    # @params job_id [String]
+    def initialize(script: nil, params: nil, base_job_dir: nil, job_id: nil)
+      @script       = script
+      @params       = params
+      @base_job_dir = base_job_dir
+      @job_id       = job_id
     end
 
     def setup_dir

--- a/paraduct.gemspec
+++ b/paraduct.gemspec
@@ -17,6 +17,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
+  spec.required_ruby_version = ">= 2.0.0"
 
   spec.add_dependency "activesupport", "~> 4.0"
   spec.add_dependency "colorize"
@@ -36,9 +37,4 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rspec-retry"
   spec.add_development_dependency "rspec-temp_dir"
   spec.add_development_dependency "yard"
-
-  if RUBY_VERSION.to_i >= 2
-    # NOTE: pry-byebug doesn't support ruby 1.9
-    spec.add_development_dependency "pry-byebug"
-  end
 end


### PR DESCRIPTION
* net-ssh (dependency of specinfra) requirements ruby 2.0+
* https://github.com/net-ssh/net-ssh/blob/v3.1.0/net-ssh.gemspec#L192