### PR TITLE
Refactor logger

### DIFF
--- a/lib/paraduct/colored_label_logger.rb
+++ b/lib/paraduct/colored_label_logger.rb
@@ -3,20 +3,8 @@ module Paraduct
     def initialize(label_name, logdev = STDOUT)
       super(logdev)
       color = Paraduct::ColoredLabelLogger.next_color
-      # @label = "[#{label_name.to_s.colorize(color)}]"
-      # @formatter = ActiveSupport::Logger::SimpleFormatter.new
       @formatter = Formatter.new(label_name, color)
     end
-
-    # SEVERITIES = [:debug, :info, :warn, :error, :fatal]
-    # SEVERITIES.each do |severity|
-    #   define_method "#{severity}_with_label" do |message|
-    #     message.each_line do |line|
-    #       send "#{severity}_without_label", "#{@label} #{line.strip}" unless line.blank?
-    #     end
-    #   end
-    #   alias_method_chain severity, :label
-    # end
 
     COLORS = [
       :cyan,
@@ -49,7 +37,7 @@ module Paraduct
 
         content = ""
         message.each_line do |line|
-          content << "#{@label} #{line.strip}\n"
+          content << "#{@label} #{datetime}: #{line.strip}\n"
         end
         content
       end

--- a/lib/paraduct/colored_label_logger.rb
+++ b/lib/paraduct/colored_label_logger.rb
@@ -37,7 +37,7 @@ module Paraduct
 
         content = ""
         message.each_line do |line|
-          content << "#{@label} #{datetime}: #{line.strip}\n"
+          content << "#{datetime} #{@label} #{line.strip}\n"
         end
         content
       end

--- a/lib/paraduct/colored_label_logger.rb
+++ b/lib/paraduct/colored_label_logger.rb
@@ -33,9 +33,9 @@ module Paraduct
       :light_blue,
     ]
     def self.next_color
-      @@color_index ||= -1
-      @@color_index = (@@color_index + 1) % COLORS.length
-      COLORS[@@color_index]
+      @color_index ||= -1
+      @color_index = (@color_index + 1) % COLORS.length
+      COLORS[@color_index]
     end
   end
 end

--- a/lib/paraduct/colored_label_logger.rb
+++ b/lib/paraduct/colored_label_logger.rb
@@ -3,19 +3,20 @@ module Paraduct
     def initialize(label_name, logdev = STDOUT)
       super(logdev)
       color = Paraduct::ColoredLabelLogger.next_color
-      @label = "[#{label_name.to_s.colorize(color)}]"
-      @formatter = ActiveSupport::Logger::SimpleFormatter.new
+      # @label = "[#{label_name.to_s.colorize(color)}]"
+      # @formatter = ActiveSupport::Logger::SimpleFormatter.new
+      @formatter = Formatter.new(label_name, color)
     end
 
-    SEVERITIES = [:debug, :info, :warn, :error, :fatal]
-    SEVERITIES.each do |severity|
-      define_method "#{severity}_with_label" do |message|
-        message.each_line do |line|
-          send "#{severity}_without_label", "#{@label} #{line.strip}" unless line.blank?
-        end
-      end
-      alias_method_chain severity, :label
-    end
+    # SEVERITIES = [:debug, :info, :warn, :error, :fatal]
+    # SEVERITIES.each do |severity|
+    #   define_method "#{severity}_with_label" do |message|
+    #     message.each_line do |line|
+    #       send "#{severity}_without_label", "#{@label} #{line.strip}" unless line.blank?
+    #     end
+    #   end
+    #   alias_method_chain severity, :label
+    # end
 
     COLORS = [
       :cyan,
@@ -36,6 +37,22 @@ module Paraduct
       @color_index ||= -1
       @color_index = (@color_index + 1) % COLORS.length
       COLORS[@color_index]
+    end
+
+    class Formatter
+      def initialize(label_name, color)
+        @label = "[#{label_name.to_s.colorize(color)}]"
+      end
+
+      def call(severity, datetime, progname, message)
+        return "" if message.blank?
+
+        content = ""
+        message.each_line do |line|
+          content << "#{@label} #{line.strip}\n"
+        end
+        content
+      end
     end
   end
 end

--- a/lib/paraduct/runner.rb
+++ b/lib/paraduct/runner.rb
@@ -48,7 +48,7 @@ module Paraduct
 
     def logger
       unless @logger
-        stdout_logger = Paraduct::ColoredLabelLogger.new(object_id)
+        stdout_logger = Paraduct::ColoredLabelLogger.new(formatted_params)
         file_logger   = Logger.new(Pathname(@base_job_dir).join("#{job_name}.log"))
         @logger       = stdout_logger.extend(ActiveSupport::Logger.broadcast(file_logger))
       end


### PR DESCRIPTION
* Add timestamp
* use label param name instead of `object_id`

```
2016-03-21 22:33:58 +0900 [RUBY=2.0, DATABASE=postgresql] [START] params: RUBY=2.0, DATABASE=postgresql
2016-03-21 22:33:58 +0900 [RUBY=1.9, DATABASE=mysql] [START] params: RUBY=1.9, DATABASE=mysql
2016-03-21 22:33:58 +0900 [RUBY=2.0, DATABASE=postgresql] RUBY=2.0 DATABASE=postgresql
2016-03-21 22:33:58 +0900 [RUBY=2.0, DATABASE=postgresql] [END]   params: RUBY=2.0, DATABASE=postgresql
2016-03-21 22:33:58 +0900 [RUBY=1.9, DATABASE=mysql] RUBY=1.9 DATABASE=mysql
2016-03-21 22:33:58 +0900 [RUBY=1.9, DATABASE=mysql] [END]   params: RUBY=1.9, DATABASE=mysql
```