### PR TITLE
Use thor v0.19.0+

### DIFF
--- a/paraduct.gemspec
+++ b/paraduct.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "activesupport"
   spec.add_dependency "colorize"
   spec.add_dependency "rsync"
-  spec.add_dependency "thor"
+  spec.add_dependency "thor", ">= 0.19.0"
   spec.add_dependency "thread"
 
   spec.add_development_dependency "bundler", ">= 1.5"


### PR DESCRIPTION
```bash
$ be rspec -- spec/paraduct/cli_spec.rb:94
Run options: include {:locations=>{"./spec/paraduct/cli_spec.rb"=>[94]}}

Randomized with seed 58420
Could not find ".paraduct.yml" in any of your source paths. Your current source paths are:
/Users/sue445/workspace/github.com/sue445/paraduct/lib/paraduct/templates
FCould not find ".paraduct.yml" in any of your source paths. Your current source paths are:
/Users/sue445/workspace/github.com/sue445/paraduct/lib/paraduct/templates
F

Failures:

  1) Paraduct::CLI#generate whether copy .paraduct_rsync_exclude.txt should be exist
     Failure/Error: it { expect(generated_config_file).to be_exist }
       expected `#<Pathname:/var/folders/24/nfw8gds54jv2j6r1sjrnpv4c0000gn/T/rspec-20171119-7317-2u6my4/.paraduct_rsync_exclude.txt>.exist?` to return true, got false
     # ./spec/paraduct/cli_spec.rb:99:in `block (5 levels) in <top (required)>'
     # ./vendor/bundle/ruby/2.4.0/gems/rspec-temp_dir-1.0.0/lib/rspec/temp_dir/uses_temp_dir.rb:9:in `block (3 levels) in <top (required)>'
     # ./vendor/bundle/ruby/2.4.0/gems/rspec-temp_dir-1.0.0/lib/rspec/temp_dir/uses_temp_dir.rb:7:in `block (2 levels) in <top (required)>'

  2) Paraduct::CLI#generate whether copy .paraduct.yml should be exist
     Failure/Error: it { expect(generated_config_file).to be_exist }
       expected `#<Pathname:/var/folders/24/nfw8gds54jv2j6r1sjrnpv4c0000gn/T/rspec-20171119-7317-1mcpukm/.paraduct.yml>.exist?` to return true, got false
     # ./spec/paraduct/cli_spec.rb:99:in `block (5 levels) in <top (required)>'
     # ./vendor/bundle/ruby/2.4.0/gems/rspec-temp_dir-1.0.0/lib/rspec/temp_dir/uses_temp_dir.rb:9:in `block (3 levels) in <top (required)>'
     # ./vendor/bundle/ruby/2.4.0/gems/rspec-temp_dir-1.0.0/lib/rspec/temp_dir/uses_temp_dir.rb:7:in `block (2 levels) in <top (required)>'

Finished in 0.1237 seconds (files took 3.22 seconds to load)
2 examples, 2 failures
```

`.tt` is available since v0.19.0
https://github.com/erikhuda/thor/blob/master/CHANGELOG.md#0190-release-2014-03-22

But travis installing older thor

```bash
$ bundle install --jobs=2 --path=${BUNDLE_PATH:-vendor/bundle}

(snip)

Fetching thor 0.18.1
Installing thor 0.18.1
```

https://travis-ci.org/sue445/paraduct/jobs/296698341